### PR TITLE
Fix assets inclusion for Rails 5 and greater

### DIFF
--- a/lib/wicked_pdf/railtie.rb
+++ b/lib/wicked_pdf/railtie.rb
@@ -17,13 +17,12 @@ if defined?(Rails)
       end
     end
 
-  elsif Rails::VERSION::MAJOR == 5
-
-    unless ActionView::Base.ancestors.include?(PdfHelper)
-      ActionController::Base.send :prepend, PdfHelper
-    end
-    unless ActionView::Base.instance_methods.include? 'wicked_pdf_stylesheet_link_tag'
-      ActionView::Base.send :include, WickedPdfHelper
+  elsif Rails::VERSION::MAJOR >= 5
+    class WickedRailtie < Rails::Railtie
+      initializer 'wicked_pdf.register' do |_app|
+        ActionController::Base.send :prepend, PdfHelper
+        ActionView::Base.send :include, WickedPdfHelper::Assets
+      end
     end
 
   elsif Rails::VERSION::MAJOR == 2


### PR DESCRIPTION
This commit modifies https://github.com/mileszs/wicked_pdf/pull/519 to fix for asset pipeline (in tests, at a minimum) and ensure it does not need another update just to change a version number when Rails 6 comes out.

If you pull it in, it should automatically be added to the main PR.

Thanks!
